### PR TITLE
nfc: pn553: Fix enum-conversion warnings

### DIFF
--- a/drivers/nfc/pn553-i2c/pn553.c
+++ b/drivers/nfc/pn553-i2c/pn553.c
@@ -454,7 +454,7 @@ static void p61_get_access_state(struct pn544_dev *pn544_dev, p61_access_state_t
     }
 }
 
-static int signal_handler(p61_access_state_t state, long nfc_pid)
+static int signal_handler(unsigned long state, long nfc_pid)
 {
     struct siginfo sinfo;
     pid_t pid;


### PR DESCRIPTION
fix for:

../drivers/nfc/pn553-i2c/pn553.c:1260:32: warning: implicit conversion from enumeration type 'enum jcop_dwnld_state' to different enumeration type 'p61_access_state_t' (aka 'enum p61_access_state') [-Wenum-conversion]

../drivers/nfc/pn553-i2c/pn553.c:1289:32: warning: implicit conversion from enumeration type 'enum jcop_dwnld_state' to different enumeration type 'p61_access_state_t' (aka 'enum p61_access_state') [-Wenum-conversion]